### PR TITLE
handle different names for configparser module based on python version

### DIFF
--- a/fcrepo-import-export-tests/verify/verify.py
+++ b/fcrepo-import-export-tests/verify/verify.py
@@ -26,7 +26,7 @@ from __future__ import absolute_import, division, print_function
 import settings
 
 import argparse
-from configparser import SafeConfigParser
+import sys
 import hashlib
 import os
 
@@ -34,6 +34,11 @@ import logging
 
 from source import HttpSource
 from source import FileSource
+
+if sys.version_info[0] < 3:
+    from ConfigParser import SafeConfigParser
+else:
+    from configparser import SafeConfigParser
 
 CONFIG = 'config.ini'
 REPORT_FILE = 'verification_report.txt'


### PR DESCRIPTION
This change creates a check for which version of the python interpreter is being used and will import configparser using the appropriate module name.  It requires the sys module.
