### PR TITLE
Issue1

### DIFF
--- a/fcrepo-import-export-tests/verify/source.py
+++ b/fcrepo-import-export-tests/verify/source.py
@@ -57,7 +57,9 @@ class FileSource(Source):
         self.bin_dir = bin_dir.replace('file://', '')
 
         self.to_check = [self.desc_dir + self.ext]
-        for dirpath, dirname, filenames in os.walk(self.desc_dir.replace('file://', ''), onerror=FileSource.walkfailed):
+        for dirpath, dirname, filenames in os.walk(self.desc_dir,
+                                                 onerror=FileSource.walkfailed
+                                                 ):
             for name in filenames:
                 self.to_check.append(os.path.join(dirpath,name))
 

--- a/fcrepo-import-export-tests/verify/source.py
+++ b/fcrepo-import-export-tests/verify/source.py
@@ -33,6 +33,12 @@ logger = logging.getLogger('output')
 class Source() :
     def __init__ (self, baseUri):
         self.baseUri = baseUri
+    
+    def __str__(self):
+        return self.baseUri
+
+    def __iter__(self):
+        return self
 
     def getBaseUri(self):
         return self.baseUri
@@ -54,12 +60,6 @@ class FileSource(Source):
         for dirpath, dirname, filenames in os.walk(self.desc_dir.replace('file://', ''), onerror=FileSource.walkfailed):
             for name in filenames:
                 self.to_check.append(os.path.join(dirpath,name))
-
-    def __str__(self):
-        return self.baseUri
-
-    def __iter__(self):
-        return self
 
     def __next__(self):
         if not self.to_check:
@@ -105,16 +105,10 @@ class HttpSource(Source):
 
     def __init__(self, baseUri, auth):
         Source.__init__(self, baseUri)
-        self.auth = tuple(auth.split(':'))
+        self.auth = auth
 
         # back up one directory to get the rest.xyz file
         self.to_check = [baseUri]
-
-    def __str__(self):
-        return self.baseUri
-
-    def __iter__(self):
-        return self
 
     def fetchBinaryResource(self, aresource):
         resource = aresource

--- a/fcrepo-import-export-tests/verify/verify.py
+++ b/fcrepo-import-export-tests/verify/verify.py
@@ -24,12 +24,10 @@
 from __future__ import absolute_import, division, print_function
 
 import settings
-
 import argparse
 import sys
 import hashlib
 import os
-
 import logging
 
 from source import HttpSource
@@ -170,38 +168,75 @@ def translate_to_desc(origin, recipient, resource):
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--loglevel', help='Level of output into log [DEBUG, INFO, WARN, ERROR], ' +
-                        'default is WARN. To list the records being looked at, set this to INFO', default='WARN')
+    parser.add_argument('--loglevel', 
+                        help='''Level of output into log [DEBUG, INFO, WARN, 
+                                ERROR], default is WARN. To list the records 
+                                being looked at, set this to INFO''',
+                        default='WARN')
+    parser.add_argument('--config', '-c', help='Path to import/export config')
+    parser.add_argument('--user', '-u', help='''Server credentials in the form
+                                                user:password''')
+                        
     args = parser.parse_args()
 
     settings.init()
 
-    cfgParser = SafeConfigParser()
-    cfgParser.read(CONFIG)
+    if not args.config:
+        cfgParser = SafeConfigParser()
+        cfgParser.read(CONFIG)
+        test_mode = cfgParser.get('general', 'test_mode')
 
-    out_file = cfgParser.get('general', 'report_dir') + REPORT_FILE
+        fedoraUrl = cfgParser.get('fedora1', 'baseUri')
+        auth = tuple(cfgParser.get('fedora1', 'auth').split(':'))
+
+        fileDir = cfgParser.get('file1', 'baseUri')
+        if not fileDir.endswith('/'):
+            fileDir += '/'
+
+        fileExt = cfgParser.get('file1', 'ext')
+
+        binDir = (fileDir + 
+                  cfgParser.get('file1', 'bin_path') + 
+                  cfgParser.get('file1', 'prefix')
+                  )
+        descDir = (fileDir + 
+                   cfgParser.get('file1', 'desc_path') + 
+                   cfgParser.get('file1', 'prefix')
+                   )
+        out_file = cfgParser.get('general', 'report_dir') + REPORT_FILE
+        
+    else:
+        print("loading opts from import/export config file")
+        with open(args.config, 'r') as f:
+            opts = [line for line in f.read().split('\n')]
+
+        for line in range(len(opts)):
+            if opts[line] == '-m':
+                test_mode = opts[line + 1]
+            elif opts[line] == '-r':
+                fedoraUrl = opts[line + 1]
+            elif opts[line] == '-d':
+                descDir = opts[line + 1]
+            elif opts[line] == '-b':
+                binDir = opts[line + 1]
+            elif opts[line] == '-x':
+                fileExt = opts[line + 1]
+            elif opts[line] == '-l':
+                pass
+            else:
+                pass
+        
+        fileDir = '/'
+        out_file = './verification_report.txt'
+        auth = tuple(args.user.split(':'))
 
     loglevel = args.loglevel
     numeric_level = getattr(logging, loglevel.upper(), None)
     logger = logging.getLogger('output')
-    filehandler = logging.FileHandler(filename=REPORT_FILE, mode='w')
+    filehandler = logging.FileHandler(filename=out_file, mode='w')
     filehandler.setLevel(numeric_level)
     logger.addHandler(filehandler)
     logger.setLevel(numeric_level)
-
-    test_mode = cfgParser.get('general', 'test_mode')
-
-    fedoraUrl = cfgParser.get('fedora1', 'baseUri')
-    auth = cfgParser.get('fedora1', 'auth')
-
-    fileDir = cfgParser.get('file1', 'baseUri')
-    if not fileDir.endswith('/'):
-        fileDir += '/'
-
-    fileExt = cfgParser.get('file1', 'ext')
-
-    binDir = fileDir + cfgParser.get('file1', 'bin_path') + cfgParser.get('file1', 'prefix')
-    descDir = fileDir + cfgParser.get('file1', 'desc_path') + cfgParser.get('file1', 'prefix')
 
     logger.debug('bin_dir = {0}\ndesc_dir = {1}'.format(binDir, descDir))
 

--- a/fcrepo-import-export-tests/verify/verify.py
+++ b/fcrepo-import-export-tests/verify/verify.py
@@ -216,9 +216,9 @@ if __name__ == '__main__':
             elif opts[line] == '-r':
                 fedoraUrl = opts[line + 1]
             elif opts[line] == '-d':
-                descDir = opts[line + 1]
+                descPath = opts[line + 1]
             elif opts[line] == '-b':
-                binDir = opts[line + 1]
+                binPath = opts[line + 1]
             elif opts[line] == '-x':
                 fileExt = opts[line + 1]
             elif opts[line] == '-l':
@@ -226,7 +226,9 @@ if __name__ == '__main__':
             else:
                 pass
         
-        fileDir = '/'
+        fileDir = os.path.commonprefix([descPath, binPath])
+        descDir = fileDir + os.path.relpath(descPath, fileDir) + "/rest"
+        binDir = fileDir + os.path.relpath(binPath, fileDir) + "/rest"
         out_file = './verification_report.txt'
         auth = tuple(args.user.split(':'))
 


### PR DESCRIPTION
Allows tests to be run using the config generated by the import/export tool.  Specify the location of this config file using the -c/--config option.  Because the import/export config does not contain authentication info, you must specify that info with the -u/--user option if authentication is required to access the Fedora being checked.

If no config option is specified at the command line, the default config.ini will be used, as previously.

This pull reuqest also fixes a bug where a specified location for the verifcation_report.txt was not respected and the report was always created in the script directory (see below verify.py line 187 orig/238 new).
